### PR TITLE
refactor: display percentages as whole numbers

### DIFF
--- a/Sources/Helpers/Formatting.swift
+++ b/Sources/Helpers/Formatting.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum Formatting {
-    /// Format a percentage value: "12.3%" or "12%".
-    static func percent(_ value: Double, decimals: Int = 1) -> String {
+    /// Format a percentage value: "12%" (no decimals by default).
+    static func percent(_ value: Double, decimals: Int = 0) -> String {
         String(format: "%.\(decimals)f%%", value)
     }
 

--- a/Sources/Models/PaceCalculation.swift
+++ b/Sources/Models/PaceCalculation.swift
@@ -25,9 +25,9 @@ struct PaceCalculation: Sendable {
         if abs(delta) < 1 {
             return "On pace"
         } else if isOverpacing {
-            return String(format: "%.1f%% ahead", delta)
+            return String(format: "%.0f%% ahead", delta)
         } else {
-            return String(format: "%.1f%% behind", abs(delta))
+            return String(format: "%.0f%% behind", abs(delta))
         }
     }
 

--- a/Sources/Views/Dashboard/SamplesPageView.swift
+++ b/Sources/Views/Dashboard/SamplesPageView.swift
@@ -110,7 +110,7 @@ struct SamplesPageView: View {
 
                 TableColumn("5H %") { row in
                     if let value = row.fiveHour {
-                        Text(String(format: "%.1f%%", value))
+                        Text(String(format: "%.0f%%", value))
                             .monospacedDigit()
                             .foregroundStyle(.blue)
                     }
@@ -119,7 +119,7 @@ struct SamplesPageView: View {
 
                 TableColumn("7D %") { row in
                     if let value = row.sevenDay {
-                        Text(String(format: "%.1f%%", value))
+                        Text(String(format: "%.0f%%", value))
                             .monospacedDigit()
                             .foregroundStyle(.purple)
                     }

--- a/Sources/Views/Dashboard/UnifiedChartView.swift
+++ b/Sources/Views/Dashboard/UnifiedChartView.swift
@@ -788,12 +788,12 @@ struct UnifiedChartView: View {
             HStack(spacing: 8) {
                 HStack(spacing: 3) {
                     Circle().fill(.blue).frame(width: 6, height: 6)
-                    Text(String(format: "5h: %.1f%%", snap.fiveHourUtilization))
+                    Text(String(format: "5h: %.0f%%", snap.fiveHourUtilization))
                         .font(.caption2.monospacedDigit())
                 }
                 HStack(spacing: 3) {
                     Circle().fill(.purple).frame(width: 6, height: 6)
-                    Text(String(format: "7d: %.1f%%", snap.sevenDayUtilization))
+                    Text(String(format: "7d: %.0f%%", snap.sevenDayUtilization))
                         .font(.caption2.monospacedDigit())
                 }
             }
@@ -807,12 +807,12 @@ struct UnifiedChartView: View {
             if !filteredSnapshots.isEmpty {
                 statItem(
                     "Peak 5H",
-                    value: String(format: "%.1f%%", filteredSnapshots.map(\.fiveHourUtilization).max() ?? 0),
+                    value: String(format: "%.0f%%", filteredSnapshots.map(\.fiveHourUtilization).max() ?? 0),
                     color: .blue
                 )
                 statItem(
                     "Peak 7D",
-                    value: String(format: "%.1f%%", filteredSnapshots.map(\.sevenDayUtilization).max() ?? 0),
+                    value: String(format: "%.0f%%", filteredSnapshots.map(\.sevenDayUtilization).max() ?? 0),
                     color: .purple
                 )
             }

--- a/Sources/Views/Dashboard/UsageGaugeView.swift
+++ b/Sources/Views/Dashboard/UsageGaugeView.swift
@@ -214,7 +214,7 @@ struct SevenDayCard: View {
     var projection: WindowProjection?
 
     private var displayPercent: Double {
-        projection?.currentGranularUtilization() ?? window.percentUsed
+        window.percentUsed
     }
 
     private var gaugeColor: Color {
@@ -236,13 +236,8 @@ struct SevenDayCard: View {
                 Gauge(value: displayPercent / 100) {
                     EmptyView()
                 } currentValueLabel: {
-                    if projection != nil {
-                        Text(Formatting.percent(displayPercent))
-                            .font(.system(.title2, design: .rounded, weight: .bold).monospacedDigit())
-                    } else {
-                        Text("\(Int(displayPercent))%")
-                            .font(.system(.title, design: .rounded, weight: .bold).monospacedDigit())
-                    }
+                    Text("\(Int(displayPercent))%")
+                        .font(.system(.title, design: .rounded, weight: .bold).monospacedDigit())
                 }
                 .gaugeStyle(.accessoryCircular)
                 .tint(gaugeColor.gradient)

--- a/Sources/Views/MenuBar/UsageSummaryRow.swift
+++ b/Sources/Views/MenuBar/UsageSummaryRow.swift
@@ -55,7 +55,7 @@ struct UsageSummaryRow: View {
                         Text("7-day window")
                             .font(.caption.weight(.medium))
                             .foregroundStyle(.secondary)
-                        usageBar(window: sevenDay, granularPercent: projection?.currentGranularUtilization())
+                        usageBar(window: sevenDay)
                         Text(paceSubtitle(window: sevenDay, showReset: false))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -98,8 +98,8 @@ struct UsageSummaryRow: View {
         return paceText
     }
 
-    private func usageBar(window: UsageWindow, granularPercent: Double? = nil) -> some View {
-        let displayPercent = granularPercent ?? window.percentUsed
+    private func usageBar(window: UsageWindow) -> some View {
+        let displayPercent = window.percentUsed
         let displayNormalized = displayPercent / 100
         let windowLabel = window.duration <= 18001 ? "5-hour" : "7-day"
         return HStack(spacing: 6) {
@@ -114,15 +114,9 @@ struct UsageSummaryRow: View {
             }
             .frame(height: 6)
             .accessibilityHidden(true)
-            if granularPercent != nil {
-                Text(Formatting.percent(displayPercent))
-                    .font(.caption2.monospacedDigit().weight(.medium))
-                    .frame(width: 38, alignment: .trailing)
-            } else {
-                Text("\(Int(displayPercent))%")
-                    .font(.caption2.monospacedDigit().weight(.medium))
-                    .frame(width: 30, alignment: .trailing)
-            }
+            Text("\(Int(displayPercent))%")
+                .font(.caption2.monospacedDigit().weight(.medium))
+                .frame(width: 30, alignment: .trailing)
             PaceIndicator(window: window)
         }
         .accessibilityElement(children: .ignore)


### PR DESCRIPTION
## Summary
- Drop decimal places from all percent readouts: gauges, samples table, chart stats, summary rows, and pace deltas.
- Integer percentages match the granularity of the underlying data and read more cleanly in tight UI.

## Test plan
- [ ] Dashboard gauges show integer percentages
- [ ] Samples table shows integer 5H/7D columns
- [ ] Pace deltas (\"X% ahead/behind\") display as integers