### PR TITLE
fix: reset manual-entry state when navigating back in onboarding

### DIFF
--- a/Sources/Views/Dashboard/OnboardingView.swift
+++ b/Sources/Views/Dashboard/OnboardingView.swift
@@ -271,7 +271,13 @@ struct OnboardingView: View {
 
     private func backButton(to targetPage: Int) -> some View {
         Button {
-            withAnimation { page = targetPage }
+            withAnimation {
+                if targetPage <= 2 {
+                    showManualEntry = false
+                    viewModel.error = nil
+                }
+                page = targetPage
+            }
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "arrow.left")
@@ -497,7 +503,7 @@ struct OnboardingView: View {
                 || viewModel.isValidating
             )
 
-            Text("Paste an OAuth token from your Anthropic account settings.")
+            Text("Paste an OAuth token from Claude Code's credentials file\nor Keychain.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary
- Going back to an earlier onboarding page left the manual-entry form visible with stale errors. Clear those when stepping back past page 2.
- Update the token caption to point at Claude Code's credentials file/Keychain rather than the (non-existent) Anthropic settings page.

## Test plan
- [ ] Open onboarding, advance to manual entry, type something, hit back — form is reset and no stale error remains
- [ ] Token caption text reads correctly