### PR TITLE
feat(accounts): support custom .claude config directory per account

### DIFF
--- a/Sources/App/ClusageApp.swift
+++ b/Sources/App/ClusageApp.swift
@@ -39,6 +39,7 @@ struct ClusageApp: App {
             .task {
                 recordStartupGap()
                 accountStore.refreshAllFromKeychain()
+                tokenUsageStore.scanner.updateExtraDirectories(from: accountStore.accounts)
                 tokenUsageStore.refresh()
                 tokenUsageStore.refreshSessions()
                 startPolling()

--- a/Sources/Models/Account.swift
+++ b/Sources/Models/Account.swift
@@ -16,6 +16,9 @@ struct Account: Identifiable, Codable, Sendable {
     /// Custom path to a `.credentials.json` file for this account.
     /// When nil, defaults to `~/.claude/.credentials.json`.
     var credentialsFilePath: String?
+    /// Custom path to the `.claude` configuration directory for this account.
+    /// When nil, defaults to `~/.claude`. Affects session scanning for cost estimates.
+    var claudeConfigDir: String?
     /// Per-account usage schedule.
     var usagePlan: UsagePlan = UsagePlan()
 
@@ -38,7 +41,7 @@ struct Account: Identifiable, Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, fiveHour, sevenDay, profile, lastUpdated, lastError
-        case keychainServiceName, tokenExpiresAt, credentialsFilePath, usagePlan
+        case keychainServiceName, tokenExpiresAt, credentialsFilePath, claudeConfigDir, usagePlan
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +56,7 @@ struct Account: Identifiable, Codable, Sendable {
         keychainServiceName = try c.decodeIfPresent(String.self, forKey: .keychainServiceName)
         tokenExpiresAt = try c.decodeIfPresent(Date.self, forKey: .tokenExpiresAt)
         credentialsFilePath = try c.decodeIfPresent(String.self, forKey: .credentialsFilePath)
+        claudeConfigDir = try c.decodeIfPresent(String.self, forKey: .claudeConfigDir)
         usagePlan = try c.decodeIfPresent(UsagePlan.self, forKey: .usagePlan) ?? UsagePlan()
     }
 }

--- a/Sources/Services/SessionScanner.swift
+++ b/Sources/Services/SessionScanner.swift
@@ -7,7 +7,9 @@ import Foundation
 @MainActor final class SessionScanner {
     private(set) var isScanning = false
 
-    private let projectsDir: URL
+    private let defaultProjectsDir: URL
+    /// Additional project directories from accounts with custom `.claude` config dirs.
+    private(set) var extraProjectsDirs: [URL] = []
     private let offsetsFileURL: URL
     /// Track the byte offset we've already read for each file (incremental reads).
     private var fileOffsets: [String: UInt64] = [:]
@@ -23,9 +25,21 @@ import Foundation
         return f
     }()
 
+    /// All project directories to scan (default + extras, deduplicated).
+    private var allProjectsDirs: [URL] {
+        var dirs = [defaultProjectsDir]
+        let defaultPath = defaultProjectsDir.standardizedFileURL.path
+        for dir in extraProjectsDirs {
+            if dir.standardizedFileURL.path != defaultPath {
+                dirs.append(dir)
+            }
+        }
+        return dirs
+    }
+
     init() {
         let home = FileManager.default.homeDirectoryForCurrentUser
-        self.projectsDir = home.appendingPathComponent(".claude/projects", isDirectory: true)
+        self.defaultProjectsDir = home.appendingPathComponent(".claude/projects", isDirectory: true)
 
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let dir = appSupport.appendingPathComponent("Clusage", isDirectory: true)
@@ -33,6 +47,16 @@ import Foundation
         self.offsetsFileURL = dir.appendingPathComponent("scanner-offsets.json")
 
         loadOffsets()
+    }
+
+    /// Update the set of extra project directories from account configurations.
+    func updateExtraDirectories(from accounts: [Account]) {
+        extraProjectsDirs = accounts.compactMap { account in
+            guard let dir = account.claudeConfigDir else { return nil }
+            let expanded = NSString(string: dir).expandingTildeInPath
+            return URL(fileURLWithPath: expanded, isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
     }
 
     /// Scan all session JSONL files and return new token events since last scan.
@@ -45,14 +69,10 @@ import Foundation
         }
 
         let fm = FileManager.default
-        guard fm.fileExists(atPath: projectsDir.path) else {
-            Log.tokens.debug("Projects directory not found: \(self.projectsDir.path)")
-            return []
-        }
-
         var results: [(model: String, date: String, usage: TokenUsage, newSession: Bool)] = []
 
         let jsonlFiles = findJSONLFiles()
+        guard !jsonlFiles.isEmpty else { return [] }
 
         for fileURL in jsonlFiles {
             let path = fileURL.path
@@ -122,13 +142,13 @@ import Foundation
     /// of a parent session. Uses cached summaries and only reads new bytes.
     func scanSessions(since cutoffDate: String) -> [SessionSummary] {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: projectsDir.path) else { return [] }
-
-        // Only scan top-level session JSONL files (not subagents)
-        guard let projectDirs = fm.contentsOfDirectory(atPath: projectsDir.path, includingHidden: false) else { return [] }
 
         // Track which sessions we see this scan to prune stale cache entries
         var seenSessionIDs = Set<String>()
+
+        for projectsDir in allProjectsDirs {
+        guard fm.fileExists(atPath: projectsDir.path) else { continue }
+        guard let projectDirs = fm.contentsOfDirectory(atPath: projectsDir.path, includingHidden: false) else { continue }
 
         for projectName in projectDirs {
             let projectDir = projectsDir.appendingPathComponent(projectName)
@@ -188,6 +208,7 @@ import Foundation
                 }
             }
         }
+        } // end for projectsDir in allProjectsDirs
 
         // Prune cache entries for deleted files
         cachedSessions = cachedSessions.filter { seenSessionIDs.contains($0.key) }
@@ -297,10 +318,12 @@ import Foundation
 
     private func findJSONLFiles() -> [URL] {
         let fm = FileManager.default
-        guard let projectEnumerator = fm.contentsOfDirectory(atPath: projectsDir.path,
-                                                              includingHidden: false) else { return [] }
-
         var files: [URL] = []
+
+        for projectsDir in allProjectsDirs {
+        guard let projectEnumerator = fm.contentsOfDirectory(atPath: projectsDir.path,
+                                                              includingHidden: false) else { continue }
+
         for projectName in projectEnumerator {
             let projectDir = projectsDir.appendingPathComponent(projectName)
             guard let contents = fm.contentsOfDirectory(atPath: projectDir.path, includingHidden: false) else { continue }
@@ -319,6 +342,7 @@ import Foundation
                 }
             }
         }
+        } // end for projectsDir in allProjectsDirs
         return files
     }
 

--- a/Sources/Services/TokenUsageStore.swift
+++ b/Sources/Services/TokenUsageStore.swift
@@ -9,7 +9,7 @@ import Foundation
 
     private let fileURL: URL
     private let sessionsFileURL: URL
-    private let scanner: SessionScanner
+    let scanner: SessionScanner
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()

--- a/Sources/Services/UsagePoller.swift
+++ b/Sources/Services/UsagePoller.swift
@@ -396,6 +396,7 @@ import Foundation
 
         widgetWriter.write(accounts: accountStore.accounts)
         momentumProvider?.refresh()
+        tokenUsageStore?.scanner.updateExtraDirectories(from: accountStore.accounts)
         tokenUsageStore?.refresh()
         apiFileWriter.write(accounts: accountStore.accounts, momentumProvider: momentumProvider, tokenUsageStore: tokenUsageStore)
 

--- a/Sources/ViewModels/AccountsViewModel.swift
+++ b/Sources/ViewModels/AccountsViewModel.swift
@@ -55,14 +55,14 @@ final class AccountsViewModel {
         error = nil
 
         do {
-            _ = try await APIClient.shared.validateToken(token)
             let profile = try await APIClient.shared.fetchProfile(token: token)
 
             // Resolve keychain binding: use selected credential, or match against
             // already-detected credentials (avoids a new keychain scan + prompts)
+            let matchedCredential = detectedCredentials.first(where: { $0.accessToken == token })
             var keychainService = selectedKeychainServiceName
             if keychainService == nil {
-                keychainService = detectedCredentials.first(where: { $0.accessToken == token })?.serviceName
+                keychainService = matchedCredential?.serviceName
                 if let service = keychainService {
                     Log.accounts.info("Auto-detected keychain entry '\(service)' for manual token")
                 }
@@ -72,7 +72,9 @@ final class AccountsViewModel {
                 name: name,
                 token: token,
                 profile: Profile(from: profile),
-                keychainServiceName: keychainService
+                keychainServiceName: keychainService,
+                refreshToken: matchedCredential?.refreshToken,
+                tokenExpiresAt: matchedCredential?.expiresAt
             )
             Log.accounts.info("Account '\(name)' added successfully (keychain: \(keychainService ?? "none"))")
             newAccountName = ""
@@ -164,8 +166,6 @@ final class AccountsViewModel {
         var failedLabels: [String] = []
         for credential in uniqueImports {
             do {
-                // validateToken hits usage endpoint — confirms the token works
-                _ = try await APIClient.shared.validateToken(credential.accessToken)
                 let profile = try await APIClient.shared.fetchProfile(token: credential.accessToken)
                 let name = profile.account.email
                 accountStore.addAccount(

--- a/Sources/Views/Accounts/AccountsPageView.swift
+++ b/Sources/Views/Accounts/AccountsPageView.swift
@@ -207,7 +207,6 @@ struct AccountsPageView: View {
             defer { importingIDs.remove(credential.id) }
 
             do {
-                _ = try await APIClient.shared.validateToken(credential.accessToken)
                 let profile = try await APIClient.shared.fetchProfile(token: credential.accessToken)
                 let name = profile.account.email
                 accountStore.addAccount(
@@ -243,7 +242,6 @@ struct AccountsPageView: View {
             defer { isValidatingCustom = false }
 
             do {
-                _ = try await APIClient.shared.validateToken(token)
                 let profile = try await APIClient.shared.fetchProfile(token: token)
 
                 // Auto-detect keychain binding
@@ -273,6 +271,7 @@ private struct AccountRow: View {
     var onDelete: () -> Void
     @State private var showingRelinkSheet = false
     @State private var showingCredentialsPathSheet = false
+    @State private var showingClaudeConfigDirSheet = false
 
     private var isMenuBarAccount: Bool {
         accountStore.menuBarAccountID == account.id
@@ -309,6 +308,14 @@ private struct AccountRow: View {
 
                 if let customPath = account.credentialsFilePath {
                     Text(customPath)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                if let configDir = account.claudeConfigDir {
+                    Text(configDir)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
@@ -367,6 +374,10 @@ private struct AccountRow: View {
                 showingCredentialsPathSheet = true
             }
 
+            Button("Set Claude Config Directory…") {
+                showingClaudeConfigDirSheet = true
+            }
+
             Button("Re-link Keychain Entry…") {
                 showingRelinkSheet = true
             }
@@ -382,6 +393,133 @@ private struct AccountRow: View {
         }
         .sheet(isPresented: $showingCredentialsPathSheet) {
             CredentialsPathSheet(account: account, accountStore: accountStore)
+        }
+        .sheet(isPresented: $showingClaudeConfigDirSheet) {
+            ClaudeConfigDirSheet(account: account, accountStore: accountStore)
+        }
+    }
+}
+
+/// Sheet that lets the user set a custom `.claude` config directory for an account.
+private struct ClaudeConfigDirSheet: View {
+    let account: Account
+    let accountStore: AccountStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var path: String = ""
+    @State private var validationStatus: ValidationStatus = .idle
+
+    private enum ValidationStatus: Equatable {
+        case idle
+        case valid
+        case invalid(String)
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Claude Config Directory")
+                .font(.title2.bold())
+
+            Text("Set the path to the `.claude` directory for **\(account.displayName)**. This is where Claude Code stores session data used for cost estimates.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    TextField("~/.claude", text: $path)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+
+                    Button("Browse…") { browseForDirectory() }
+                }
+
+                switch validationStatus {
+                case .idle:
+                    EmptyView()
+                case .valid:
+                    Label("Directory found — contains projects/", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                case .invalid(let message):
+                    Label(message, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+
+            HStack {
+                if account.claudeConfigDir != nil {
+                    Button("Reset to Default") {
+                        var updated = account
+                        updated.claudeConfigDir = nil
+                        accountStore.updateAccount(updated)
+                        dismiss()
+                    }
+                }
+
+                Spacer()
+
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 480)
+        .onAppear {
+            path = account.claudeConfigDir ?? ""
+        }
+        .onChange(of: path) {
+            validate()
+        }
+    }
+
+    private func validate() {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            validationStatus = .idle
+            return
+        }
+
+        let expanded = NSString(string: trimmed).expandingTildeInPath
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+
+        guard fm.fileExists(atPath: expanded, isDirectory: &isDir), isDir.boolValue else {
+            validationStatus = .invalid("Directory not found")
+            return
+        }
+
+        let projectsDir = URL(fileURLWithPath: expanded).appendingPathComponent("projects")
+        if fm.fileExists(atPath: projectsDir.path, isDirectory: &isDir), isDir.boolValue {
+            validationStatus = .valid
+        } else {
+            validationStatus = .invalid("Directory exists but has no projects/ subdirectory")
+        }
+    }
+
+    private func save() {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        var updated = account
+        updated.claudeConfigDir = trimmed.isEmpty ? nil : trimmed
+        accountStore.updateAccount(updated)
+        dismiss()
+    }
+
+    private func browseForDirectory() {
+        let panel = NSOpenPanel()
+        panel.title = "Select .claude Directory"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+
+        if panel.runModal() == .OK, let url = panel.url {
+            path = url.path
         }
     }
 }
@@ -486,8 +624,9 @@ private struct RelinkKeychainView: View {
         error = nil
 
         Task { @MainActor in
+            let profile: ProfileResponse
             do {
-                _ = try await APIClient.shared.validateToken(credential.accessToken)
+                profile = try await APIClient.shared.fetchProfile(token: credential.accessToken)
             } catch {
                 self.error = "Token validation failed: \(error.localizedDescription)"
                 isValidating = false
@@ -495,18 +634,15 @@ private struct RelinkKeychainView: View {
             }
 
             if let expectedEmail = account.profile?.email,
-               let credentialEmail = credential.email,
-               credentialEmail != expectedEmail {
-                self.error = "This credential belongs to \(credentialEmail), not \(expectedEmail)."
+               profile.account.email != expectedEmail {
+                self.error = "This credential belongs to \(profile.account.email), not \(expectedEmail)."
                 isValidating = false
                 return
             }
 
-            if account.profile == nil, let email = credential.email {
-                var updated = account
-                updated.profile = Profile(email: email)
-                accountStore.updateAccount(updated)
-            }
+            var updated = account
+            updated.profile = Profile(from: profile)
+            accountStore.updateAccount(updated)
 
             accountStore.relinkKeychain(for: account, credential: credential)
             isValidating = false


### PR DESCRIPTION
## Summary
- Add a per-account override for the \`.claude\` directory used during session scanning, so users with multiple Claude installations can map each account to its own session data.
- Accounts page gets a new \"Set Claude Config Directory…\" sheet with browse + live validation.
- \`SessionScanner\` now walks the union of default + per-account dirs.
- Tighten account add/import/relink to use \`fetchProfile\` directly (validateToken called the same endpoint internally) and carry refresh token + expiry from detected credentials when adding a manually-pasted token.

## Test plan
- [ ] Set a custom \`.claude\` dir on an account → sessions from that dir appear in cost estimates
- [ ] Reset to default removes the override
- [ ] Adding/importing/relinking accounts still works end-to-end