### PR TITLE
feat(menubar): bring dashboard window to active Space when opened

### DIFF
--- a/Sources/App/ClusageApp.swift
+++ b/Sources/App/ClusageApp.swift
@@ -46,7 +46,7 @@ struct ClusageApp: App {
                 updateChecker.startIfEnabled()
                 hotkeyManager.start { [openWindow] in
                     openWindow(id: "dashboard")
-                    NSApp.activate()
+                    bringDashboardToFront()
                 }
             }
         }

--- a/Sources/Views/MenuBar/MenuBarView.swift
+++ b/Sources/Views/MenuBar/MenuBarView.swift
@@ -45,7 +45,7 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                     Button("Get Started") {
-                        openWindow(id: "dashboard")
+                        openDashboard()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
@@ -58,7 +58,7 @@ struct MenuBarView: View {
 
             HStack(spacing: 8) {
                 Button {
-                    openWindow(id: "dashboard")
+                    openDashboard()
                 } label: {
                     Text("Open Dashboard")
                         .font(.callout.weight(.medium))
@@ -100,5 +100,19 @@ struct MenuBarView: View {
             .padding(.vertical, 10)
         }
         .frame(width: 320)
+    }
+
+    private func openDashboard() {
+        openWindow(id: "dashboard")
+        bringDashboardToFront()
+    }
+}
+
+/// Activate the app and move the Dashboard window to the current Space.
+@MainActor func bringDashboardToFront() {
+    NSApp.activate()
+    if let window = NSApp.windows.first(where: { $0.title == "Dashboard" }) {
+        window.collectionBehavior.insert(.moveToActiveSpace)
+        window.makeKeyAndOrderFront(nil)
     }
 }


### PR DESCRIPTION
## Summary
- Opening the dashboard from the menu bar or the global hotkey would leave it stranded on whichever Space it last lived on.
- Activate the app and force the window to follow to the active Space so it actually appears in front of the user.

## Test plan
- [ ] Open dashboard, switch to another Space, click the menu bar / hit hotkey → dashboard appears on the current Space
- [ ] Dashboard still receives focus correctly after open