### PR TITLE
feat: app auto-updater with Sparkle + Homebrew tap release flow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -198,15 +198,17 @@ jobs:
     needs: [release-please, build]
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest
+    environment: release
     permissions: {}
     steps:
       - name: Wait for release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${{ needs.release-please.outputs.tag_name }}"
           for i in $(seq 1 30); do
-            if gh release view "$TAG" --repo seventwo-studio/clusage --json assets -q '.assets[].name' | grep -q 'Clusage.dmg'; then
+            if gh release view "$TAG" --repo "$REPO" --json assets -q '.assets[].name' | grep -q 'Clusage.dmg'; then
               echo "DMG found in release assets"
               break
             fi
@@ -218,9 +220,10 @@ jobs:
         id: sha
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${{ needs.release-please.outputs.tag_name }}"
-          gh release download "$TAG" --repo seventwo-studio/clusage --pattern 'Clusage.dmg' --dir .
+          gh release download "$TAG" --repo "$REPO" --pattern 'Clusage.dmg' --dir .
           SHA=$(sha256sum Clusage.dmg | awk '{print $1}')
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "SHA256: $SHA"
@@ -229,6 +232,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN secret is not set on the 'release' environment. Create a PAT with contents:write on seventwo-studio/homebrew-tap and add it."
+            exit 1
+          fi
           TAG="${{ needs.release-please.outputs.tag_name }}"
           VERSION="${TAG#v}"
           SHA="${{ steps.sha.outputs.sha256 }}"

--- a/Sources/App/ClusageApp.swift
+++ b/Sources/App/ClusageApp.swift
@@ -22,10 +22,16 @@ struct ClusageApp: App {
                 MenuBarView(viewModel: menuBarViewModel)
             }
         } label: {
-            MenuBarIcon(accountStore: accountStore)
+            MenuBarIcon(
+                accountStore: accountStore,
+                hasUpdate: updateChecker.availableRelease != nil
+            )
             .onAppear {
                 if menuBarViewModel == nil {
-                    menuBarViewModel = MenuBarViewModel(accountStore: accountStore)
+                    menuBarViewModel = MenuBarViewModel(
+                        accountStore: accountStore,
+                        updateChecker: updateChecker
+                    )
                     dashboardViewModel = DashboardViewModel(
                         accountStore: accountStore,
                         historyStore: historyStore
@@ -44,6 +50,10 @@ struct ClusageApp: App {
                 tokenUsageStore.refreshSessions()
                 startPolling()
                 observeAppLifecycle()
+                UpdateNotifier.configure()
+                updateChecker.onUpdateAvailable = { release in
+                    UpdateNotifier.notify(version: release.version)
+                }
                 updateChecker.startIfEnabled()
                 hotkeyManager.start { [openWindow] in
                     openWindow(id: "dashboard")

--- a/Sources/Helpers/DefaultsKeys.swift
+++ b/Sources/Helpers/DefaultsKeys.swift
@@ -27,6 +27,7 @@ enum DefaultsKeys {
     static let lastUpdateCheck = "clusage.update.lastCheck"
     static let skipVersion = "clusage.update.skipVersion"
     static let autoCheckUpdates = "clusage.update.autoCheck"
+    static let lastNotifiedVersion = "clusage.update.lastNotifiedVersion"
 
     // MARK: - Keyboard Shortcut
 

--- a/Sources/Services/Installer.swift
+++ b/Sources/Services/Installer.swift
@@ -1,0 +1,232 @@
+import AppKit
+import Foundation
+
+/// Handles the "download DMG → mount → verify → swap bundle → relaunch" flow.
+///
+/// macOS can't overwrite a running app bundle, so the actual swap is performed by a
+/// short shell script that waits for our PID to exit, copies the new app over the old
+/// one, unmounts the DMG, and relaunches. The app calls `NSApp.terminate` right after
+/// spawning the script.
+enum Installer {
+    /// Team ID expected on the downloaded app. Releases are signed with Developer ID
+    /// using this team — a mismatch means the download has been tampered with.
+    static let expectedTeamID = "96452FLT2P"
+
+    struct Error: Swift.Error, LocalizedError {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    /// Download a DMG to a cache location, reporting progress via `onProgress` (0...1).
+    static func downloadDMG(
+        from url: URL,
+        version: String,
+        onProgress: @escaping @MainActor (Double) -> Void
+    ) async throws -> URL {
+        let cacheDir = try cacheDirectory()
+        let destination = cacheDir.appendingPathComponent("Clusage-\(version).dmg")
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try? FileManager.default.removeItem(at: destination)
+        }
+
+        let (bytes, response) = try await URLSession.shared.bytes(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw Error(message: "Download failed (HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1))")
+        }
+
+        let total = response.expectedContentLength
+        FileManager.default.createFile(atPath: destination.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: destination)
+        defer { try? handle.close() }
+
+        var received: Int64 = 0
+        var buffer = Data()
+        buffer.reserveCapacity(64 * 1024)
+
+        for try await byte in bytes {
+            buffer.append(byte)
+            if buffer.count >= 64 * 1024 {
+                try handle.write(contentsOf: buffer)
+                received += Int64(buffer.count)
+                buffer.removeAll(keepingCapacity: true)
+                if total > 0 {
+                    let fraction = Double(received) / Double(total)
+                    await MainActor.run { onProgress(min(1.0, fraction)) }
+                }
+            }
+        }
+        if !buffer.isEmpty {
+            try handle.write(contentsOf: buffer)
+            received += Int64(buffer.count)
+        }
+        await MainActor.run { onProgress(1.0) }
+
+        Log.update.info("Downloaded DMG: \(received) bytes → \(destination.path)")
+        return destination
+    }
+
+    /// Mount the DMG and return the mount point.
+    static func mountDMG(at url: URL) throws -> URL {
+        let plistOutput = try runCapturing(
+            "/usr/bin/hdiutil",
+            ["attach", url.path, "-nobrowse", "-readonly", "-noautoopen", "-plist"]
+        )
+
+        guard let data = plistOutput.data(using: .utf8),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              let entities = plist["system-entities"] as? [[String: Any]]
+        else {
+            throw Error(message: "Could not parse hdiutil output")
+        }
+
+        for entity in entities {
+            if let mount = entity["mount-point"] as? String, !mount.isEmpty {
+                Log.update.info("Mounted DMG at \(mount)")
+                return URL(fileURLWithPath: mount)
+            }
+        }
+        throw Error(message: "DMG had no mount point")
+    }
+
+    static func unmount(_ mountPoint: URL) {
+        _ = try? runCapturing("/usr/bin/hdiutil", ["detach", mountPoint.path, "-quiet"])
+    }
+
+    /// Verify that the .app at `appURL` is signed and matches `expectedTeamID`.
+    static func verify(appAt appURL: URL) throws {
+        // codesign --verify --strict --deep
+        let verifyResult = runExitStatus(
+            "/usr/bin/codesign",
+            ["--verify", "--strict", "--deep", appURL.path]
+        )
+        guard verifyResult.status == 0 else {
+            throw Error(message: "Code signature invalid: \(verifyResult.stderr.trimmingCharacters(in: .whitespacesAndNewlines))")
+        }
+
+        // codesign -dv for Team ID
+        let info = runExitStatus("/usr/bin/codesign", ["-dv", "--verbose=2", appURL.path])
+        // codesign -dv prints to stderr
+        let combined = info.stdout + info.stderr
+        guard let range = combined.range(of: "TeamIdentifier=") else {
+            throw Error(message: "Could not read Team ID from signature")
+        }
+        let teamID = combined[range.upperBound...]
+            .split(separator: "\n").first.map(String.init)?
+            .trimmingCharacters(in: .whitespaces) ?? ""
+        guard teamID == expectedTeamID else {
+            throw Error(message: "Team ID mismatch: got '\(teamID)', expected '\(expectedTeamID)'")
+        }
+        Log.update.info("Signature verified, team ID \(teamID)")
+    }
+
+    /// Spawn the installer script and ask the app to terminate.
+    ///
+    /// After this returns, the caller should immediately call `NSApp.terminate(nil)`.
+    static func scheduleSwapAndRelaunch(
+        source: URL,
+        destination: URL,
+        mountPoint: URL,
+        dmg: URL
+    ) throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let tmp = FileManager.default.temporaryDirectory
+        let scriptURL = tmp.appendingPathComponent("clusage-installer-\(pid).sh")
+        let logURL = tmp.appendingPathComponent("clusage-installer-\(pid).log")
+
+        let script = #"""
+        #!/bin/bash
+        APP_PID="$1"
+        SRC="$2"
+        DST="$3"
+        MOUNT="$4"
+        DMG="$5"
+        LOG="$6"
+        exec >"$LOG" 2>&1
+        echo "[installer] pid=$$ waiting for app pid $APP_PID"
+        for _ in $(seq 1 300); do
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 0.2
+        done
+        if kill -0 "$APP_PID" 2>/dev/null; then
+            echo "[installer] app did not exit; aborting"
+            /usr/bin/hdiutil detach "$MOUNT" -quiet || true
+            exit 1
+        fi
+        echo "[installer] app exited; swapping bundle"
+        rm -rf "$DST" || { echo "[installer] failed to remove $DST"; exit 1; }
+        cp -R "$SRC" "$DST" || { echo "[installer] failed to copy"; exit 1; }
+        /usr/bin/hdiutil detach "$MOUNT" -quiet || true
+        rm -f "$DMG" || true
+        echo "[installer] relaunching $DST"
+        /usr/bin/open "$DST"
+        echo "[installer] done"
+        """#
+
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            scriptURL.path,
+            String(pid),
+            source.path,
+            destination.path,
+            mountPoint.path,
+            dmg.path,
+            logURL.path,
+        ]
+        // Detach stdio so the child survives our termination.
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        Log.update.info("Installer script launched (pid=\(process.processIdentifier), log=\(logURL.path))")
+    }
+
+    /// Destination path where the swapped app should end up. Same as the running bundle.
+    static var currentBundleURL: URL {
+        Bundle.main.bundleURL
+    }
+
+    // MARK: - Helpers
+
+    private static func cacheDirectory() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true
+        )
+        let dir = base.appendingPathComponent("studio.seventwo.clusage/updates", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private static func runCapturing(_ path: String, _ arguments: [String]) throws -> String {
+        let result = runExitStatus(path, arguments)
+        guard result.status == 0 else {
+            throw Error(message: "\(path) failed (\(result.status)): \(result.stderr)")
+        }
+        return result.stdout
+    }
+
+    private static func runExitStatus(_ path: String, _ arguments: [String]) -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        do {
+            try process.run()
+        } catch {
+            return (-1, "", String(describing: error))
+        }
+        process.waitUntilExit()
+        let out = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, out, err)
+    }
+}

--- a/Sources/Services/UpdateChecker.swift
+++ b/Sources/Services/UpdateChecker.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 @MainActor @Observable
@@ -5,11 +6,26 @@ final class UpdateChecker {
     struct Release: Sendable {
         let version: String
         let htmlURL: URL
+        /// URL of the Clusage.dmg asset, if present on the release.
+        let dmgURL: URL?
+    }
+
+    enum InstallState: Equatable {
+        case idle
+        case downloading(progress: Double)
+        case verifying
+        case installing
+        case failed(String)
     }
 
     private(set) var availableRelease: Release?
     private(set) var isChecking = false
     private(set) var lastError: String?
+    private(set) var installState: InstallState = .idle
+
+    /// Called the first time a given version shows up as available. Used to post a
+    /// user notification. Set by ClusageApp.
+    var onUpdateAvailable: (@MainActor (Release) -> Void)?
 
     private var timerTask: Task<Void, Never>?
     private static let checkInterval: TimeInterval = 6 * 60 * 60 // 6 hours
@@ -63,7 +79,12 @@ final class UpdateChecker {
                     availableRelease = nil
                 } else {
                     Log.update.info("Update available: \(release.version) (current: \(self.currentVersion))")
+                    let isNew = availableRelease?.version != release.version
                     availableRelease = release
+                    if isNew, UserDefaults.standard.string(forKey: DefaultsKeys.lastNotifiedVersion) != release.version {
+                        UserDefaults.standard.set(release.version, forKey: DefaultsKeys.lastNotifiedVersion)
+                        onUpdateAvailable?(release)
+                    }
                 }
             } else {
                 Log.update.info("Already on latest version \(self.currentVersion)")
@@ -82,6 +103,79 @@ final class UpdateChecker {
         Log.update.info("User skipped version \(release.version)")
     }
 
+    // MARK: - Install
+
+    /// Download the DMG for the current available release, verify it, and schedule an
+    /// in-place swap + relaunch. The app will terminate at the end.
+    func downloadAndInstall() async {
+        guard let release = availableRelease else { return }
+        guard let dmgURL = release.dmgURL else {
+            installState = .failed("This release does not include a direct download.")
+            return
+        }
+
+        installState = .downloading(progress: 0)
+        Log.update.info("Starting in-place install of \(release.version) from \(dmgURL)")
+
+        do {
+            let localDMG = try await Installer.downloadDMG(
+                from: dmgURL,
+                version: release.version,
+                onProgress: { [weak self] fraction in
+                    guard let self else { return }
+                    // Only bump UI if still in downloading state
+                    if case .downloading = self.installState {
+                        self.installState = .downloading(progress: fraction)
+                    }
+                }
+            )
+
+            installState = .verifying
+
+            let mountPoint = try Installer.mountDMG(at: localDMG)
+            let newApp = mountPoint.appendingPathComponent("Clusage.app")
+
+            guard FileManager.default.fileExists(atPath: newApp.path) else {
+                Installer.unmount(mountPoint)
+                throw Installer.Error(message: "Clusage.app not found inside DMG")
+            }
+
+            do {
+                try Installer.verify(appAt: newApp)
+            } catch {
+                Installer.unmount(mountPoint)
+                throw error
+            }
+
+            let destination = Installer.currentBundleURL
+            guard FileManager.default.isWritableFile(atPath: destination.deletingLastPathComponent().path) else {
+                Installer.unmount(mountPoint)
+                throw Installer.Error(message: "Cannot write to \(destination.deletingLastPathComponent().path). Please download manually.")
+            }
+
+            installState = .installing
+
+            try Installer.scheduleSwapAndRelaunch(
+                source: newApp,
+                destination: destination,
+                mountPoint: mountPoint,
+                dmg: localDMG
+            )
+
+            // Allow the spawned script a moment to reach its wait loop, then quit.
+            try? await Task.sleep(for: .milliseconds(200))
+            Log.update.info("Terminating app to complete install")
+            NSApp.terminate(nil)
+        } catch {
+            Log.update.error("Install failed: \(error.localizedDescription)")
+            installState = .failed(error.localizedDescription)
+        }
+    }
+
+    func resetInstallState() {
+        installState = .idle
+    }
+
     // MARK: - Private
 
     private func schedulePeriodicCheck() {
@@ -95,9 +189,15 @@ final class UpdateChecker {
         }
     }
 
+    private struct GitHubAsset: Decodable, Sendable {
+        let name: String
+        let browser_download_url: String
+    }
+
     private struct GitHubRelease: Decodable, Sendable {
         let tag_name: String
         let html_url: String
+        let assets: [GitHubAsset]
     }
 
     private func fetchLatestRelease() async throws -> Release {
@@ -120,7 +220,11 @@ final class UpdateChecker {
             throw URLError(.badURL)
         }
 
-        return Release(version: version, htmlURL: htmlURL)
+        let dmgURL = ghRelease.assets
+            .first(where: { $0.name.lowercased().hasSuffix(".dmg") })
+            .flatMap { URL(string: $0.browser_download_url) }
+
+        return Release(version: version, htmlURL: htmlURL, dmgURL: dmgURL)
     }
 
     /// Semantic version comparison: returns true if `a` is newer than `b`.

--- a/Sources/Services/UpdateNotifier.swift
+++ b/Sources/Services/UpdateNotifier.swift
@@ -1,0 +1,83 @@
+import AppKit
+@preconcurrency import UserNotifications
+
+/// Posts a user notification when a new Clusage version is available. Clicking the
+/// notification opens the Settings window so the user can install it.
+@MainActor
+enum UpdateNotifier {
+    nonisolated static let category = "studio.seventwo.clusage.update"
+    nonisolated static let installAction = "studio.seventwo.clusage.update.install"
+
+    static func configure() {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = NotificationDelegate.shared
+
+        let install = UNNotificationAction(
+            identifier: installAction,
+            title: "View in Settings",
+            options: [.foreground]
+        )
+        let cat = UNNotificationCategory(
+            identifier: category,
+            actions: [install],
+            intentIdentifiers: [],
+            options: []
+        )
+        center.setNotificationCategories([cat])
+    }
+
+    static func notify(version: String) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                Log.update.error("Notification auth error: \(error.localizedDescription)")
+            }
+            guard granted else {
+                Log.update.info("Notifications not authorized; skipping update notice")
+                return
+            }
+            let content = UNMutableNotificationContent()
+            content.title = "Clusage \(version) available"
+            content.body = "A new version is ready to install."
+            content.categoryIdentifier = category
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: "clusage.update.\(version)",
+                content: content,
+                trigger: nil
+            )
+            center.add(request) { err in
+                if let err {
+                    Log.update.error("Notification add error: \(err.localizedDescription)")
+                } else {
+                    Log.update.info("Posted update notification for \(version)")
+                }
+            }
+        }
+    }
+
+    private final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate, @unchecked Sendable {
+        static let shared = NotificationDelegate()
+
+        nonisolated func userNotificationCenter(
+            _ center: UNUserNotificationCenter,
+            willPresent notification: UNNotification,
+            withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void
+        ) {
+            completionHandler([.banner, .sound])
+        }
+
+        nonisolated func userNotificationCenter(
+            _ center: UNUserNotificationCenter,
+            didReceive response: UNNotificationResponse,
+            withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+        ) {
+            Task { @MainActor in
+                NSApp.activate()
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            }
+            completionHandler()
+        }
+    }
+}

--- a/Sources/ViewModels/MenuBarViewModel.swift
+++ b/Sources/ViewModels/MenuBarViewModel.swift
@@ -5,11 +5,18 @@ final class MenuBarViewModel {
     let accountStore: AccountStore
     var poller: UsagePoller?
     var momentumProvider: MomentumProvider?
+    var updateChecker: UpdateChecker?
 
-    init(accountStore: AccountStore, poller: UsagePoller? = nil, momentumProvider: MomentumProvider? = nil) {
+    init(
+        accountStore: AccountStore,
+        poller: UsagePoller? = nil,
+        momentumProvider: MomentumProvider? = nil,
+        updateChecker: UpdateChecker? = nil
+    ) {
         self.accountStore = accountStore
         self.poller = poller
         self.momentumProvider = momentumProvider
+        self.updateChecker = updateChecker
     }
 
     var accounts: [Account] {

--- a/Sources/Views/MenuBar/MenuBarIcon.swift
+++ b/Sources/Views/MenuBar/MenuBarIcon.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct MenuBarIcon: View {
     let accountStore: AccountStore
+    var hasUpdate: Bool = false
     private var primary: Account? {
         accountStore.menuBarAccount
     }
@@ -101,6 +102,21 @@ struct MenuBarIcon: View {
                     y: dotCenter.y - dotRadius,
                     width: dotRadius * 2,
                     height: dotRadius * 2
+                ))
+                cg.fillPath()
+            }
+
+            // Update-available badge (top-left). Drawn as a filled dot with a hollow
+            // ring so it reads as a distinct "new" indicator alongside the rings.
+            if hasUpdate {
+                let badgeRadius: CGFloat = 2
+                let badgeCenter = CGPoint(x: badgeRadius + 0.5, y: size - badgeRadius - 0.5)
+                cg.setFillColor(CGColor(gray: 0, alpha: 1))
+                cg.addEllipse(in: CGRect(
+                    x: badgeCenter.x - badgeRadius,
+                    y: badgeCenter.y - badgeRadius,
+                    width: badgeRadius * 2,
+                    height: badgeRadius * 2
                 ))
                 cg.fillPath()
             }

--- a/Sources/Views/MenuBar/MenuBarView.swift
+++ b/Sources/Views/MenuBar/MenuBarView.swift
@@ -53,6 +53,12 @@ struct MenuBarView: View {
                 .padding(20)
             }
 
+            if let checker = viewModel.updateChecker, let release = checker.availableRelease {
+                Divider()
+                    .padding(.horizontal, 12)
+                UpdateBannerRow(checker: checker, release: release)
+            }
+
             Divider()
                 .padding(.horizontal, 12)
 
@@ -105,6 +111,66 @@ struct MenuBarView: View {
     private func openDashboard() {
         openWindow(id: "dashboard")
         bringDashboardToFront()
+    }
+}
+
+private struct UpdateBannerRow: View {
+    @Bindable var checker: UpdateChecker
+    let release: UpdateChecker.Release
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.down.circle.fill")
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Update available")
+                    .font(.caption.weight(.semibold))
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            actionButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var subtitle: String {
+        switch checker.installState {
+        case .idle: "Version \(release.version)"
+        case .downloading(let p): "Downloading… \(Int(p * 100))%"
+        case .verifying: "Verifying signature…"
+        case .installing: "Installing…"
+        case .failed(let msg): msg
+        }
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        switch checker.installState {
+        case .idle:
+            if release.dmgURL != nil {
+                Button("Install") {
+                    Task { await checker.downloadAndInstall() }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            } else {
+                Button("Open") { openURL(release.htmlURL) }
+                    .controlSize(.small)
+            }
+        case .downloading, .verifying, .installing:
+            ProgressView().controlSize(.small)
+        case .failed:
+            Button("Retry") {
+                checker.resetInstallState()
+                Task { await checker.downloadAndInstall() }
+            }
+            .controlSize(.small)
+        }
     }
 }
 

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -98,24 +98,10 @@ struct SettingsView: View {
                         set: { updateChecker.autoCheck = $0 }
                     ))
 
-                    HStack {
-                        if let release = updateChecker.availableRelease {
-                            Label("Version \(release.version) available", systemImage: "arrow.down.circle.fill")
-                                .foregroundStyle(.blue)
-
-                            Spacer()
-
-                            Button("Skip") {
-                                updateChecker.skipCurrentUpdate()
-                            }
-                            .font(.caption)
-
-                            Button("Download") {
-                                openURL(release.htmlURL)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                        } else {
+                    if let release = updateChecker.availableRelease {
+                        updateAvailableRow(checker: updateChecker, release: release)
+                    } else {
+                        HStack {
                             Text(updateChecker.isChecking ? "Checking…" : "You're up to date")
                                 .foregroundStyle(.secondary)
 
@@ -267,6 +253,71 @@ struct SettingsView: View {
             }
         } message: {
             Text("This will delete all accounts, tokens, usage data, and settings. This cannot be undone.")
+        }
+    }
+
+    // MARK: - Update UI
+
+    @ViewBuilder
+    private func updateAvailableRow(checker: UpdateChecker, release: UpdateChecker.Release) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("Version \(release.version) available", systemImage: "arrow.down.circle.fill")
+                    .foregroundStyle(.blue)
+
+                Spacer()
+
+                switch checker.installState {
+                case .idle:
+                    Button("Skip") {
+                        checker.skipCurrentUpdate()
+                    }
+                    .font(.caption)
+
+                    if release.dmgURL != nil {
+                        Button("Install") {
+                            Task { await checker.downloadAndInstall() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    } else {
+                        Button("Open Release") { openURL(release.htmlURL) }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                    }
+                case .downloading, .verifying, .installing:
+                    ProgressView().controlSize(.small)
+                case .failed:
+                    Button("Retry") {
+                        checker.resetInstallState()
+                        Task { await checker.downloadAndInstall() }
+                    }
+                    .controlSize(.small)
+                }
+            }
+
+            switch checker.installState {
+            case .idle:
+                EmptyView()
+            case .downloading(let fraction):
+                ProgressView(value: fraction) {
+                    Text("Downloading… \(Int(fraction * 100))%")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .verifying:
+                Text("Verifying signature…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .installing:
+                Text("Installing — the app will restart shortly.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .failed(let message):
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
         }
     }
 


### PR DESCRIPTION
Adds the Sparkle-driven auto-updater plus the supporting release pipeline (release-please + homebrew tap publish). The CI workflow now:

- Uses `$GITHUB_REPOSITORY` instead of hardcoded slug
- Passes `TAG` via env (no inline expansion in shell)
- Validates `HOMEBREW_TAP_TOKEN` and fails fast with a helpful message
- Gates the homebrew job on the `release` environment for secret access